### PR TITLE
Altered grep regex for alphanumeric.

### DIFF
--- a/update-synclient-settings.sh
+++ b/update-synclient-settings.sh
@@ -36,7 +36,7 @@ synclient -l > $TMPFILE
 # Parse synclient output
 echo "Parsing settings..."
 while read line; do
-	if [[ $line =~ ([[:alpha:]]+)[[:space:]]*=[[:space:]]*([0-9\.]+) ]]; then
+	if [[ $line =~ ([[:alnum:]]+)[[:space:]]*=[[:space:]]*([0-9\.]+) ]]; then
 		echo "synclient "${BASH_REMATCH[1]}"="${BASH_REMATCH[2]} >> $SYNFILE
 		echo "	"${BASH_REMATCH[1]}"="${BASH_REMATCH[2]}
 	fi


### PR DESCRIPTION
The synclient settings on my machine have names that contain numbers in addition to letters. For example, I have options named "TapButton1" and "ClickButton1". The current regex ignores these settings and so my settings were not saved. This change fixes that.
